### PR TITLE
Remove MAX_TASK_STACK_SIZE assert from block_on

### DIFF
--- a/kimojio/src/lib.rs
+++ b/kimojio/src/lib.rs
@@ -98,8 +98,6 @@ use crate::configuration::BusyPoll;
 
 pub use kimojio_macros::{main, test};
 
-const MAX_TASK_STACK_SIZE: usize = 65536;
-
 enum CompletionState {
     /// The future is created but SQE is not yet submitted to the kernel
     Idle {

--- a/kimojio/src/runtime.rs
+++ b/kimojio/src/runtime.rs
@@ -7,7 +7,7 @@ use rustix::thread::sched_getcpu;
 use rustix_uring::Errno;
 
 use crate::{
-    Completion, CompletionState, MAX_TASK_STACK_SIZE, OwnedFd, RuntimeHandle,
+    Completion, CompletionState, OwnedFd, RuntimeHandle,
     configuration::{BusyPoll, Configuration},
     task::{Task, TaskReadyState, TaskState},
     task_ref::create_waker,
@@ -332,8 +332,6 @@ impl Runtime {
     where
         Fut: Future + 'static,
     {
-        assert!(std::mem::size_of::<Fut>() <= MAX_TASK_STACK_SIZE);
-
         let mut task_state = TaskState::get();
 
         // Set a new activity_id for each uringruntime thread


### PR DESCRIPTION
The size check on the user's future type was overly restrictive and belongs in the caller's domain, not the runtime.