### PR TITLE
fix: SenderUnbounded::send succeeds after close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "foreign-types-shared",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-macros"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "quote",
  "syn",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-tls"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "cc",
  "rustix-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/Azure/kimojio-rs"
@@ -26,9 +26,9 @@ foreign-types-shared = "0.1"
 futures = "0.3"
 impls = "1"
 intrusive-collections = "0.10"
-kimojio = { path = "kimojio", version = "0.14.1" }
-kimojio-macros = { path = "kimojio-macros", version = "0.14.1" }
-kimojio-tls = { path = "kimojio-tls", version = "0.14.1" }
+kimojio = { path = "kimojio", version = "0.15.0" }
+kimojio-macros = { path = "kimojio-macros", version = "0.15.0" }
+kimojio-tls = { path = "kimojio-tls", version = "0.15.0" }
 libc = "0.2"
 openssl = "0.10"
 pin-project-lite = "0.2"

--- a/kimojio/src/async_channel.rs
+++ b/kimojio/src/async_channel.rs
@@ -49,7 +49,7 @@ impl<T> SenderUnbounded<T> {
     }
 
     /// Closes the channel. Any further attempts to send messages will return an
-    /// error. Any messages that are already in the channel will be dropped.
+    /// error. Messages already in the channel can still be received.
     pub fn close(&self) {
         self.inner.close()
     }
@@ -169,6 +169,9 @@ impl<T> AsyncChannelUnbounded<T> {
 
     fn push_back(&self, message: T) -> std::result::Result<(), T> {
         self.queue.use_mut(|queue| {
+            if queue.closed {
+                return Err(message);
+            }
             queue.items.push_back(message);
             Ok(())
         })
@@ -623,8 +626,42 @@ mod test {
         // Now should get channel closed error
         assert_eq!(Err(ChannelError::Closed), rx.recv().await);
 
-        // Note: Unbounded channels may still allow sending after close()
-        // but will be closed when all senders are dropped
+        // After close, sending should fail and return the message
+        assert_eq!(Err(42), tx.send(42));
+    }
+
+    #[crate::test]
+    async fn test_unbounded_send_after_close_returns_error() {
+        let (tx, rx) = async_channel_unbounded();
+
+        tx.send(1).unwrap();
+        tx.close();
+
+        // Send after close must fail
+        assert_eq!(Err(2), tx.send(2));
+        assert_eq!(Err(3), tx.send(3));
+
+        // Previously queued message is still receivable
+        assert_eq!(Ok(1), rx.recv().await);
+
+        // No more messages — channel is closed
+        assert_eq!(Err(ChannelError::Closed), rx.recv().await);
+    }
+
+    #[crate::test]
+    async fn test_unbounded_cloned_sender_close_affects_all() {
+        let (tx1, rx) = async_channel_unbounded();
+        let tx2 = tx1.clone();
+
+        tx1.send(1).unwrap();
+        tx1.close();
+
+        // Both senders should fail after close
+        assert_eq!(Err(2), tx1.send(2));
+        assert_eq!(Err(3), tx2.send(3));
+
+        assert_eq!(Ok(1), rx.recv().await);
+        assert_eq!(Err(ChannelError::Closed), rx.recv().await);
     }
 
     #[crate::test]

--- a/kimojio/src/operations.rs
+++ b/kimojio/src/operations.rs
@@ -2327,10 +2327,10 @@ mod test {
 
     #[crate::test]
     async fn file_tests() {
-        let root = c"/tmp/kimojio-test";
-        let filename = c"/tmp/kimojio-test/file.txt";
-        let newpath1 = c"/tmp/kimojio-test/file.txt-1.link";
-        let newpath2 = c"/tmp/kimojio-test/file.txt-2.link";
+        let root = c"/tmp/file_tests";
+        let filename = c"/tmp/file_tests/file.txt";
+        let newpath1 = c"/tmp/file_tests/file.txt-1.link";
+        let newpath2 = c"/tmp/file_tests/file.txt-2.link";
 
         match operations::mkdir(root, 0o775.into()).await {
             Ok(()) => {}

--- a/kimojio/src/tlscontext.rs
+++ b/kimojio/src/tlscontext.rs
@@ -835,19 +835,19 @@ pub(crate) mod test {
 
         use crate::tlscontext::TlsContext;
 
-        const DEFAULT_CERT_LOCATION: &str = "/tmp/";
-        const DEFAULT_CRL_SERVER_DIR: &str = "/tmp/kimoji_server_crl";
-        const DEFAULT_CRL_CLIENT_DIR: &str = "/tmp/kimoji_client_crl";
+        const DEFAULT_CERT_LOCATION: &str = "/tmp/kimojio-test/";
+        const DEFAULT_CRL_SERVER_DIR: &str = "/tmp/kimojio-test/kimoji_server_crl";
+        const DEFAULT_CRL_CLIENT_DIR: &str = "/tmp/kimojio-test/kimoji_client_crl";
         const DEFAULT_CLIENT_NAME_SUFFIX: &str = "client.unit.tests";
         pub(crate) const DEFAULT_SERVER_NAME: &str = "server.unit.tests";
         const DEFAULT_ADMIN_NAME: &str = "admin.unit.tests";
-        const DEFAULT_SERVER_CERT_FILE: &str = "/tmp/server_kimojiotests.crt";
-        const DEFAULT_SERVER_KEY_FILE: &str = "/tmp/server_kimojiotests.key";
-        const DEFAULT_CLIENT_CERT_FILE: &str = "/tmp/client_kimojiotests.crt";
-        const DEFAULT_CLIENT_KEY_FILE: &str = "/tmp/client_kimojiotests.key";
-        const DEFAULT_CA_CERT_FILE: &str = "/tmp/ca_kimojiotests.crt";
-        const DEFAULT_CA_KEY_FILE: &str = "/tmp/ca_kimojiotests.key";
-        const DEFAULT_LOCK_FILE: &str = "/tmp/kimojiotests.lock";
+        const DEFAULT_SERVER_CERT_FILE: &str = "/tmp/kimojio-test/server_kimojiotests.crt";
+        const DEFAULT_SERVER_KEY_FILE: &str = "/tmp/kimojio-test/server_kimojiotests.key";
+        const DEFAULT_CLIENT_CERT_FILE: &str = "/tmp/kimojio-test/client_kimojiotests.crt";
+        const DEFAULT_CLIENT_KEY_FILE: &str = "/tmp/kimojio-test/client_kimojiotests.key";
+        const DEFAULT_CA_CERT_FILE: &str = "/tmp/kimojio-test/ca_kimojiotests.crt";
+        const DEFAULT_CA_KEY_FILE: &str = "/tmp/kimojio-test/ca_kimojiotests.key";
+        const DEFAULT_LOCK_FILE: &str = "/tmp/kimojio-test/kimojiotests.lock";
 
         /// Given SSL certificate, creates a client context.
         /// If `crl_path` is provided, it enables certificate revocation checking
@@ -1095,6 +1095,9 @@ certificate = {ca_cert_file}
             lock_file: &str,
             f: impl FnOnce() -> std::io::Result<()>,
         ) -> std::io::Result<()> {
+            if let Some(parent) = std::path::Path::new(lock_file).parent() {
+                fs::create_dir_all(parent)?;
+            }
             let fd = rustix::fs::open(
                 lock_file,
                 OFlags::CREATE | OFlags::TRUNC | OFlags::RDWR,
@@ -1265,6 +1268,9 @@ certificate = {ca_cert_file}
             file: &std::path::Path,
             contents: &str,
         ) -> std::io::Result<()> {
+            if let Some(parent) = file.parent() {
+                fs::create_dir_all(parent)?;
+            }
             File::create(file)
                 .unwrap_or_else(|_| panic!("Creating {} failed", file.to_str().unwrap()))
                 .write_all(contents.as_bytes())


### PR DESCRIPTION
## Summary

`SenderUnbounded::send()` silently accepted messages after the channel was closed. The internal `push_back()` method did not check the `closed` flag, unlike the bounded `Sender` which correctly returns `Err(SendError::ChannelClosed)`.

## Root Cause

`AsyncChannelUnbounded::push_back()` unconditionally pushed to the queue:
```rust
fn push_back(&self, message: T) -> Result<(), T> {
    self.queue.use_mut(|queue| {
        queue.items.push_back(message); // never checks queue.closed
        Ok(())
    })
}
```

## Fix

Add a closed check before pushing:
```rust
fn push_back(&self, message: T) -> Result<(), T> {
    self.queue.use_mut(|queue| {
        if queue.closed {
            return Err(message);
        }
        queue.items.push_back(message);
        Ok(())
    })
}
```

## Audit

Checked all channel types for send-after-close correctness:

| Type | Verdict |
|------|---------|
| `SenderUnbounded` | ❌ Fixed in this PR |
| `Sender` (bounded) | ✅ Already checks `closed` in `try_send()` |
| `SenderOneshot` | ✅ Already checks `closed` in `send()` |
| `MessagePipeSender` | ✅ N/A — OS pipe, errors come from kernel (EPIPE) |

## Tests

Added 3 regression tests:
- `test_unbounded_send_after_close_returns_error` — send after close returns `Err(message)`
- `test_unbounded_cloned_sender_close_affects_all` — close via one sender affects cloned senders
- Updated `test_sender_unbounded_close_and_status` — verifies send fails after close
