### PR TITLE
Fix yield_io/yield_cpu hang in FuturesUnordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "foreign-types-shared",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-macros"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "quote",
  "syn",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-tls"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cc",
  "rustix-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/Azure/kimojio-rs"
@@ -25,9 +25,9 @@ foreign-types-shared = "0.1"
 futures = "0.3"
 impls = "1"
 intrusive-collections = "0.10"
-kimojio = { path = "kimojio", version = "0.15.0" }
-kimojio-macros = { path = "kimojio-macros", version = "0.15.0" }
-kimojio-tls = { path = "kimojio-tls", version = "0.15.0" }
+kimojio = { path = "kimojio", version = "0.16.0" }
+kimojio-macros = { path = "kimojio-macros", version = "0.16.0" }
+kimojio-tls = { path = "kimojio-tls", version = "0.16.0" }
 libc = "0.2"
 openssl = "0.10"
 pin-project-lite = "0.2"

--- a/kimojio/src/operations.rs
+++ b/kimojio/src/operations.rs
@@ -1037,7 +1037,7 @@ pub struct SetYieldCpuFuture {
 impl Future for SetYieldCpuFuture {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut task_state = TaskState::get();
         let current_task = task_state.get_current_task();
         let current_task_state = current_task.get_state();
@@ -1050,12 +1050,18 @@ impl Future for SetYieldCpuFuture {
         match self.state {
             YieldFutureState::CreatedIo => {
                 task_state.schedule_io(current_task);
+                drop(task_state);
                 self.get_mut().state = YieldFutureState::Polled;
+                // Wake the context waker so that callers like FuturesUnordered
+                // know to re-poll this future when the task is next scheduled.
+                cx.waker().wake_by_ref();
                 Poll::Pending
             }
             YieldFutureState::CreatedCpu => {
                 task_state.schedule_cpu(current_task);
+                drop(task_state);
                 self.get_mut().state = YieldFutureState::Polled;
+                cx.waker().wake_by_ref();
                 Poll::Pending
             }
             YieldFutureState::Polled => {
@@ -2282,6 +2288,52 @@ mod test {
         crate::run_test_with_post_validate(operations::yield_io(), |stats| {
             assert!(stats.tasks_polled_io.get() > 0);
         });
+    }
+
+    #[crate::test]
+    async fn yield_io_in_futures_unordered() {
+        use std::pin::Pin;
+        type BoxFut = Pin<Box<dyn std::future::Future<Output = i32>>>;
+
+        let mut futs: FuturesUnordered<BoxFut> = FuturesUnordered::new();
+        futs.push(Box::pin(async {
+            operations::yield_io().await;
+            1
+        }));
+        futs.push(Box::pin(async {
+            operations::yield_io().await;
+            2
+        }));
+
+        let mut results = Vec::new();
+        while let Some(val) = futs.next().await {
+            results.push(val);
+        }
+        results.sort();
+        assert_eq!(results, vec![1, 2]);
+    }
+
+    #[crate::test]
+    async fn yield_cpu_in_futures_unordered() {
+        use std::pin::Pin;
+        type BoxFut = Pin<Box<dyn std::future::Future<Output = i32>>>;
+
+        let mut futs: FuturesUnordered<BoxFut> = FuturesUnordered::new();
+        futs.push(Box::pin(async {
+            operations::yield_cpu().await;
+            1
+        }));
+        futs.push(Box::pin(async {
+            operations::yield_cpu().await;
+            2
+        }));
+
+        let mut results = Vec::new();
+        while let Some(val) = futs.next().await {
+            results.push(val);
+        }
+        results.sort();
+        assert_eq!(results, vec![1, 2]);
     }
 
     #[crate::test]


### PR DESCRIPTION
yield_io() and yield_cpu() did not call the waker provided by the polling context when returning Pending. This caused FuturesUnordered (and other combinators with custom wakers) to never re-poll the sub-future, resulting in a hang.

The fix calls cx.waker().wake_by_ref() after scheduling the task, so the parent combinator knows to re-poll on the next iteration. The TaskState borrow is dropped before waking to avoid recursive borrow panics.

Also adds regression tests for both yield_io and yield_cpu inside FuturesUnordered, and bumps crate versions from 0.15.0 to 0.16.0.