### PR TITLE
Add ExitBehavior configuration flag to control runtime exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "criterion",
  "foreign-types-shared",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-macros"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "quote",
  "syn",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-tls"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "cc",
  "rustix-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/Azure/kimojio-rs"
@@ -25,9 +25,9 @@ foreign-types-shared = "0.1"
 futures = "0.3"
 impls = "1"
 intrusive-collections = "0.10"
-kimojio = { path = "kimojio", version = "0.16.2" }
-kimojio-macros = { path = "kimojio-macros", version = "0.16.2" }
-kimojio-tls = { path = "kimojio-tls", version = "0.16.2" }
+kimojio = { path = "kimojio", version = "0.16.3" }
+kimojio-macros = { path = "kimojio-macros", version = "0.16.3" }
+kimojio-tls = { path = "kimojio-tls", version = "0.16.3" }
 libc = "0.2"
 openssl = "0.10"
 pin-project-lite = "0.2"

--- a/kimojio/src/configuration.rs
+++ b/kimojio/src/configuration.rs
@@ -6,6 +6,18 @@
 
 use std::time::Duration;
 
+/// Controls when the runtime event loop exits.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub enum ExitBehavior {
+    /// Exit when there are no tasks left (default).
+    #[default]
+    WhenEmpty,
+
+    /// Exit when the main task (the future passed to `block_on`) completes,
+    /// regardless of whether other spawned tasks are still running.
+    WhenMainTaskCompletes,
+}
+
 /// Configuration options for the io_uring runtime.
 ///
 /// Use the builder pattern to customize runtime behavior.
@@ -23,6 +35,9 @@ pub struct Configuration {
     /// specific CPU cores. This is a power user feature that should only be
     /// used with careful testing and experimentation.
     pub(crate) busy_poll: BusyPoll,
+
+    /// Controls when the runtime event loop exits.
+    pub(crate) exit_behavior: ExitBehavior,
 }
 
 /// Controls whether the event loop busy-polls for I/O completion.
@@ -70,16 +85,30 @@ impl Configuration {
         self.busy_poll = busy_poll;
         self
     }
+
+    /// Sets the exit behavior for the runtime event loop.
+    pub fn set_exit_behavior(mut self, exit_behavior: ExitBehavior) -> Self {
+        self.exit_behavior = exit_behavior;
+        self
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::configuration::BusyPoll;
+    use crate::configuration::{BusyPoll, ExitBehavior};
 
     #[test]
     fn configuration_default_test() {
         let config = crate::Configuration::new();
         assert_eq!(config.busy_poll, BusyPoll::Never);
+        assert_eq!(config.exit_behavior, ExitBehavior::WhenEmpty);
         assert!(config.trace_buffer_manager.is_none());
+    }
+
+    #[test]
+    fn configuration_set_exit_behavior() {
+        let config =
+            crate::Configuration::new().set_exit_behavior(ExitBehavior::WhenMainTaskCompletes);
+        assert_eq!(config.exit_behavior, ExitBehavior::WhenMainTaskCompletes);
     }
 }

--- a/kimojio/src/runtime.rs
+++ b/kimojio/src/runtime.rs
@@ -8,7 +8,7 @@ use rustix_uring::Errno;
 
 use crate::{
     Completion, CompletionState, OwnedFd, RuntimeHandle,
-    configuration::{BusyPoll, Configuration},
+    configuration::{BusyPoll, Configuration, ExitBehavior},
     task::{FutureOrResult, Task, TaskReadyState, TaskState},
     task_ref::create_waker,
     task_state_cell::TaskStateCellRef,
@@ -296,6 +296,7 @@ pub(crate) fn submit_and_complete_io(
 
 pub struct Runtime {
     busy_poll: BusyPoll,
+    exit_behavior: ExitBehavior,
     server_pipe: OwnedFd,
     client_pipe: OwnedFd,
     // Runtime is bound to a single thread and must not be sent across threads.
@@ -309,6 +310,7 @@ impl Runtime {
         let Configuration {
             trace_buffer_manager,
             busy_poll,
+            exit_behavior,
         } = configuration;
         let mut task_state = TaskState::get();
         task_state.trace_buffer.thread_idx = thread_index;
@@ -316,6 +318,7 @@ impl Runtime {
         let (server_pipe, client_pipe) = crate::pipe::bipipe();
         Self {
             busy_poll,
+            exit_behavior,
             server_pipe,
             client_pipe,
             _not_send: std::marker::PhantomData,
@@ -378,7 +381,14 @@ impl Runtime {
         // Bail out once all tasks complete or if shutdown() is called which sets keep_running to false
         #[cfg(feature = "virtual-clock")]
         let mut idle_advance_active = true; // optimistic: try callback on first iteration
-        while task_state.get_task_count() > 0 && task_state.keep_running {
+        while task_state.keep_running {
+            let should_exit = match self.exit_behavior {
+                ExitBehavior::WhenEmpty => task_state.get_task_count() == 0,
+                ExitBehavior::WhenMainTaskCompletes => task.get_state() == TaskReadyState::Complete,
+            };
+            if should_exit {
+                break;
+            }
             // do not busy poll if the cool down time has elapsed
             let busy_poll = match self.busy_poll {
                 BusyPoll::Never => false,
@@ -838,5 +848,59 @@ mod test {
             false,
             BusyPoll::Until(std::time::Duration::from_millis(10)),
         );
+    }
+
+    #[test]
+    fn test_exit_when_empty_waits_for_spawned_tasks() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let spawned_completed = Rc::new(Cell::new(false));
+        let flag = spawned_completed.clone();
+
+        let configuration = crate::Configuration::new()
+            .set_exit_behavior(crate::configuration::ExitBehavior::WhenEmpty);
+        let result = crate::run_with_configuration(
+            0,
+            async move {
+                let event = Rc::new(AsyncEvent::new());
+                let spawned_event = event.clone();
+                operations::spawn_task(async move {
+                    // Wait until main task signals it is about to exit.
+                    spawned_event.wait().await.unwrap();
+                    flag.set(true);
+                });
+                // Signal the spawned task, then exit main.
+                event.set();
+                42
+            },
+            configuration,
+        );
+
+        assert_eq!(result.unwrap().unwrap(), 42);
+        // With WhenEmpty, the runtime waits for all tasks including the spawned one.
+        assert!(spawned_completed.get());
+    }
+
+    #[test]
+    fn test_exit_when_main_task_completes() {
+        let configuration = crate::Configuration::new()
+            .set_exit_behavior(crate::configuration::ExitBehavior::WhenMainTaskCompletes);
+        let result = crate::run_with_configuration(
+            0,
+            async move {
+                operations::spawn_task(async move {
+                    // Loop forever — runtime should exit without waiting for this.
+                    loop {
+                        operations::yield_io().await;
+                    }
+                });
+                42
+            },
+            configuration,
+        );
+
+        // The runtime returned the main task's result despite the spawned task still running.
+        assert_eq!(result.unwrap().unwrap(), 42);
     }
 }


### PR DESCRIPTION
Add a new ExitBehavior enum to Configuration that allows changing when the runtime event loop exits. The default WhenEmpty preserves existing behavior (exit when no tasks remain). The new WhenMainTaskCompletes variant exits when the main task passed to block_on completes, regardless of other spawned tasks still running.

Includes unit tests verifying both exit behaviors.