### PR TITLE
Skip io_uring_enter when only reaping completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "criterion",
  "foreign-types-shared",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-macros"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "quote",
  "syn",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-tls"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "cc",
  "rustix-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/Azure/kimojio-rs"
@@ -25,9 +25,9 @@ foreign-types-shared = "0.1"
 futures = "0.3"
 impls = "1"
 intrusive-collections = "0.10"
-kimojio = { path = "kimojio", version = "0.16.3" }
-kimojio-macros = { path = "kimojio-macros", version = "0.16.3" }
-kimojio-tls = { path = "kimojio-tls", version = "0.16.3" }
+kimojio = { path = "kimojio", version = "0.16.4" }
+kimojio-macros = { path = "kimojio-macros", version = "0.16.4" }
+kimojio-tls = { path = "kimojio-tls", version = "0.16.4" }
 libc = "0.2"
 openssl = "0.10"
 pin-project-lite = "0.2"

--- a/kimojio/src/runtime.rs
+++ b/kimojio/src/runtime.rs
@@ -264,9 +264,14 @@ pub(crate) fn submit_and_complete_io(
                 (1, enter_stats_wait)
             };
 
-            enter_stats.start();
-            let submissions = ring.submit_and_wait(want);
-            enter_stats.stop();
+            let submissions = if ring.should_enter(want) {
+                enter_stats.start();
+                let submissions = ring.submit_and_wait(want);
+                enter_stats.stop();
+                submissions
+            } else {
+                0
+            };
 
             // do not double count the submissions
             let submissions = submissions as u64;
@@ -754,6 +759,34 @@ mod test {
                     .unwrap();
                 let wait_count = crate::task::TaskState::get().enter_stats_wait.count;
                 assert_eq!(wait_count, 0);
+            },
+            false,
+            BusyPoll::Always,
+        );
+    }
+
+    #[test]
+    fn test_busy_poll_always_reaps_completion_without_enter_after_submit() {
+        crate::run_test_with_handle(
+            "test_busy_poll_always_reaps_completion_without_enter_after_submit",
+            async |_| {
+                operations::yield_io().await;
+                let enter_count = crate::task::TaskState::get().enter_stats.count;
+
+                let (read_fd, write_fd) = crate::pipe::pipe().unwrap();
+                let writer = std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    assert_eq!(rustix::io::write(&write_fd, b"x").unwrap(), 1);
+                });
+
+                let mut buf = [0u8; 1];
+                assert_eq!(operations::read(&read_fd, &mut buf).await.unwrap(), 1);
+                assert_eq!(buf, [b'x']);
+                writer.join().unwrap();
+
+                let enter_count_after_completion = crate::task::TaskState::get().enter_stats.count;
+                assert_eq!(enter_count_after_completion, enter_count + 1);
+                assert_eq!(crate::task::TaskState::get().enter_stats_wait.count, 0);
             },
             false,
             BusyPoll::Always,

--- a/kimojio/src/task.rs
+++ b/kimojio/src/task.rs
@@ -331,7 +331,7 @@ impl Ring {
     }
 
     /// Blocks if want > 0. want is the number of CQEs to wait for.
-    /// Returns the number of SQEs submitted
+    /// Returns the number of SQEs submitted.
     pub fn submit_and_wait(&self, want: usize) -> usize {
         match self.0.submitter().submit_and_wait(want) {
             Ok(submitted) => submitted,
@@ -349,6 +349,15 @@ impl Ring {
                 }
             },
         }
+    }
+
+    pub fn should_enter(&mut self, want: usize) -> bool {
+        if want > 0 || self.0.params().is_setup_iopoll() {
+            return true;
+        }
+
+        let submission = self.0.submission();
+        !submission.is_empty() || submission.cq_overflow()
     }
 
     pub fn register_probe(&self) -> rustix_uring::Probe {


### PR DESCRIPTION
io_uring exposes submission and completion queues through shared memory. Userspace needs io_uring_enter to hand pending SQEs to the kernel, and it needs io_uring_enter with GETEVENTS when it wants to wait or force kernel-side event processing. Once a request has already been submitted, however, newly produced CQEs are visible by reading the mapped CQ ring; a syscall is not required just to reap those visible completions.

Use that property in the runtime event loop by skipping submit_and_wait(0) when there is nothing to submit and the loop is not waiting. The runtime still enters the kernel whenever want > 0, the ring is IOPOLL, there are pending SQEs, or CQ_OVERFLOW is set. Those conditions preserve the existing semantics: waits still block correctly, IOPOLL still asks the kernel to advance completions, pending submissions still reach the kernel, and overflowed CQEs still get a kernel opportunity to move out of the overflow backlog.

This should reduce hot-loop overhead for busy-polling and other non-blocking reap passes by avoiding unnecessary kernel crossings, KPTI/page-table work, TLB disruption, and cache pollution. The benefit should be most visible when completions arrive while the runtime is spinning or after a task cohort produces no new SQEs.

Add a BusyPoll::Always regression test that submits a read, completes it from another thread, and proves the completion is found without an additional non-wait enter after the submit-side enter.

Bump the workspace version to 0.16.4.