### PR TITLE
Add TaskHandle completion check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "criterion",
  "foreign-types-shared",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-macros"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "quote",
  "syn",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "kimojio-tls"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "cc",
  "rustix-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.16.4"
+version = "0.16.5"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/Azure/kimojio-rs"
@@ -25,9 +25,9 @@ foreign-types-shared = "0.1"
 futures = "0.3"
 impls = "1"
 intrusive-collections = "0.10"
-kimojio = { path = "kimojio", version = "0.16.4" }
-kimojio-macros = { path = "kimojio-macros", version = "0.16.4" }
-kimojio-tls = { path = "kimojio-tls", version = "0.16.4" }
+kimojio = { path = "kimojio", version = "0.16.5" }
+kimojio-macros = { path = "kimojio-macros", version = "0.16.5" }
+kimojio-tls = { path = "kimojio-tls", version = "0.16.5" }
 libc = "0.2"
 openssl = "0.10"
 pin-project-lite = "0.2"

--- a/kimojio/src/operations.rs
+++ b/kimojio/src/operations.rs
@@ -1547,6 +1547,17 @@ impl<T: 'static> TaskHandle<T> {
         }
     }
 
+    /// Returns `true` if the task has completed.
+    ///
+    /// This checks the task state without polling the handle and does not consume
+    /// the task result.
+    pub fn is_complete(&self) -> bool {
+        match self.wait.source() {
+            Some(source) => source.task.get_state() == TaskReadyState::Complete,
+            None => true,
+        }
+    }
+
     /// Wait for a task to complete, ignoring the result.
     pub fn wait(&self) -> WaitFuture {
         WaitFuture::new(self.wait.source().unwrap().task())
@@ -2711,6 +2722,33 @@ mod test {
         let (_f1, f2) = futures::join!(task.wait(), task);
 
         assert_eq!(f2.unwrap(), 5);
+    }
+
+    #[crate::test]
+    async fn task_handle_is_complete_observes_completion_without_polling_handle() {
+        let event = Rc::new(AsyncEvent::new());
+        let task = {
+            let event = event.clone();
+            operations::spawn_task(async move {
+                event.wait().await.unwrap();
+                5
+            })
+        };
+
+        assert!(!task.is_complete());
+        operations::yield_io().await;
+        assert!(!task.is_complete());
+
+        event.set();
+        for _ in 0..100 {
+            operations::yield_io().await;
+            if task.is_complete() {
+                break;
+            }
+        }
+
+        assert!(task.is_complete());
+        assert_eq!(task.await.unwrap(), 5);
     }
 
     #[crate::test]


### PR DESCRIPTION
Expose a non-polling TaskHandle::is_complete() helper and add a regression test. Bump the workspace patch version for the public API addition.